### PR TITLE
fix: added an id attribute to the input

### DIFF
--- a/packages/wedges-vue/src/components/input/Input.vue
+++ b/packages/wedges-vue/src/components/input/Input.vue
@@ -34,6 +34,7 @@ const ariaInvalid = props.ariaInvalid ?? props.destructive;
     <div class="relative flex items-center">
       <input
         v-model="modelValue"
+        :id="elId"
         :aria-describedby="helperText ? `${elId}__describer` : undefined"
         :aria-invalid
         :aria-labelledby="label ? `${elId}__label` : undefined"


### PR DESCRIPTION
### 🔗 Linked issue

#1 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The input's label has the for attribute, specifying an element ID. However the input element does not have that ID. As such, clicking the label does not move focus to the form element. Adding the ID should resolve that.

This should resolve #1

You will need to check it is correct: you appear to use this same approach for other elements and so it _should_ work.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
